### PR TITLE
Re-compile requirements inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Compile env has UV
+# Base has Python with pip
 FROM debian:12-slim AS dev-base
 
 WORKDIR /app
@@ -7,6 +7,7 @@ RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-pip gcc libpython3-dev
 
 
+# Compile is meant to generate requirements for the last installable step
 FROM dev-base AS compile
 
 RUN --mount=type=cache,target=/root/.cache \
@@ -18,14 +19,20 @@ RUN --mount=type=cache,target=/root/.cache \
 
 COPY pyproject.toml uv.lock /app/
 
-RUN uv export --format requirements-txt --output-file /requirements.txt \
+# We want the same version of packages, but we might need more
+# because the lock file might be meant for another architecture or version of Python
+RUN uv export --format requirements-txt --output-file /constraints.txt \
     --no-editable --no-dev --no-emit-workspace --frozen \
-    --no-index
+    --no-index --no-hashes
+
+# We then compile using the constraints and our python we expect to run in production
+RUN uv pip compile --constraints /constraints.txt --output-file /requirements.txt pyproject.toml
 
 FROM dev-base AS install
 
 COPY --from=compile /requirements.txt /requirements.txt
 
+# Install everything we need into /app
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=secret,id=pip_index,env=PIP_INDEX_URL \
     --mount=type=secret,id=pip_index,env=PIP_EXTRA_INDEX_URL \
@@ -45,7 +52,7 @@ RUN --mount=type=cache,target=/root/.cache \
     --target /app \
     /tmp/*.whl
 
-FROM gcr.io/distroless/python3
+FROM gcr.io/distroless/python3-debian12:nonroot
 COPY --from=install /app /app
 WORKDIR /app
 ENV PYTHONPATH=/app


### PR DESCRIPTION
If we have a lock based on version A of Python and a docker with version B of Python, we need to make sure we re-compile the lock requirements inside the docker with version B of Python.

So we now export the lock as constraints and use the constraints to compile the requirements.